### PR TITLE
Fix HTML error rendering, skip header lines on PowerSchool schedules

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 George Moe
+Copyright (c) 2018-2022 George Moe and Dev Singh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/contributors.html
+++ b/contributors.html
@@ -22,6 +22,8 @@
 <ul>
     <li>George Moe &lt;<a href="mailto:george@george.moe">george@george.moe</a>&gt; (<a href="https://george.moe">george.moe</a>)
     </li>
+    <li>Dev Singh &lt;<a href="mailto:dev@devksingh.com">dev@devksingh.com</a>&gt; (<a href="https://devksingh.com">devksingh.com</a>)
+    </li>
     <!-- Made a contribution? Add yourself here! -->
 </ul>
 <p>Thanks everyone for helping out!</p>

--- a/index.html
+++ b/index.html
@@ -46,9 +46,6 @@
     <div class="protip protip-yellow">
         <p><b>Known bugs:</b></p>
         <ul>
-            <li>Empty lines in your schedule (such as at the end), will result in an error, but the scheduler still
-                works nonetheless. Scroll down and take a look!
-            </li>
             <li>PowerSchool's table can sometimes have quirks. If there are mistakes, you can edit the classes with the
                 Schedule Commander below. You can also use it to change the colors!
             </li>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
             screenshotting.</p>
     </div>
     <p class="protip"><i><b>That's pretty neat!</b> The Schedule Machine was first developed over the summer of 2014 as
-        a bulk-input schedule visualizer. This is its 4rd iteration. Though it's changed in looks, its
+        a bulk-input schedule visualizer. This is its 4th iteration. Though it's changed in looks, its
         goal is the same: make schedule-sharing easy and fun!</i></p>
     <h2>Fancy Auto-Scheduler</h2>
     <p class="protip protip-green"><b>This feature is experimental.</b> Copy and paste the entire semester table
@@ -288,7 +288,7 @@
             "More Settings" and enabling background graphics. If you only get black and white, try printing with your
             system print dialog.</i></p>
     </div>
-    <p id="legal">George's Schedule Machine v4.0. Copyright &copy; 2018 <a href="https://george.moe">George Moe</a></p>
+    <p id="legal">George's Schedule Machine v4.1. Copyright &copy; 2018-2022 <a href="https://george.moe">George Moe</a> and <a href="https://devksingh.com">Dev Singh</a></p>
 </div>
 </body>
 </html>

--- a/scheduler.js
+++ b/scheduler.js
@@ -172,6 +172,7 @@ $(document).ready(function () {
             var powerschool = $("#powerschool-entry").val();
             powerschool = powerschool.split("\n");
             powerschool = powerschool.map(function (entry) {
+                console.log(entry)
                 return entry.split("\t")
             });
 
@@ -271,7 +272,7 @@ $(document).ready(function () {
         } catch (e) {
             // An error occurred?? Of course. Show a message.
             var $autoMessages = $("#auto-messages");
-            html("An error occured. Please let George know what happened: <a href=\"mailto:george@george.moe\" target=\"_blank\">george@george.moe</a>.");
+            $autoMessages.html("An error occured. Please let George know what happened: <a href=\"mailto:george@george.moe\" target=\"_blank\">george@george.moe</a>.");
             $autoMessages.css("opacity", 1);
             $autoMessages.delay(5000).animate({opacity: 0}, 2000);
             console.log(e);

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,13 +1,8 @@
 // Get data from URL parameters
 // Used for parsing schedules from URLs (this feature...is under development ;) )
-function getParameterByName(name, url) {
-    if (!url) url = window.location.href;
-    name = name.replace(/[\[\]]/g, "\\$&");
-    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-        results = regex.exec(url);
-    if (!results) return null;
-    if (!results[2]) return '';
-    return decodeURIComponent(results[2].replace(/\+/g, " "));
+function getParameterByName(name) {
+    const urlParams = new URLSearchParams(window.location.search); 
+    return urlParams.get(name);
 }
 
 // Make these functions available to the DOM

--- a/scheduler.js
+++ b/scheduler.js
@@ -171,9 +171,13 @@ $(document).ready(function () {
             // Get data from the PowerSchool textfield. Split by line, and tokenize lines by tabs.
             var powerschool = $("#powerschool-entry").val();
             powerschool = powerschool.split("\n");
+            // filter out lines that do not start with numbers as they cannot possibly be valid expressions.
+            // this allows headers to be pasted.
+            powerschool = powerschool.filter((entry) => {
+               return !isNaN(entry[0]);
+            })
             powerschool = powerschool.map(function (entry) {
-                console.log(entry)
-                return entry.split("\t")
+                return entry.split("\t");
             });
 
             // Process each line in the PowerSchool schedule


### PR DESCRIPTION
When PowerSchool schedules are currently pasted in with their headers, the tool fails as the headers are not processable. This PR filters out all lines that do not start with numbers so that these headers do not cause errors. 

This PR also fixes error reporting on the PowerSchool ingest box.